### PR TITLE
Use distributed version of `GatewayDispatchPayload` for event type extraction

### DIFF
--- a/src/DiscordGateway.ts
+++ b/src/DiscordGateway.ts
@@ -26,7 +26,7 @@ export interface DiscordGateway {
   readonly fromDispatch: <K extends `${Discord.GatewayDispatchEvents}`>(
     event: K,
   ) => Stream.Stream<
-    Extract<Discord.GatewayDispatchPayload, { readonly t: K }>["d"]
+    Extract<Discord.DistributedGatewayDispatchPayload, { readonly t: K }>["d"]
   >
   readonly handleDispatch: <
     K extends `${Discord.GatewayDispatchEvents}`,
@@ -36,7 +36,10 @@ export interface DiscordGateway {
   >(
     event: K,
     handle: (
-      event: Extract<Discord.GatewayDispatchPayload, { readonly t: K }>["d"],
+      event: Extract<
+        Discord.DistributedGatewayDispatchPayload,
+        { readonly t: K }
+      >["d"],
     ) => Effect.Effect<A, E, R>,
   ) => Effect.Effect<never, E, R>
   readonly send: (payload: Discord.GatewaySendPayload) => Effect.Effect<boolean>

--- a/src/DiscordGateway/Messaging.ts
+++ b/src/DiscordGateway/Messaging.ts
@@ -12,7 +12,7 @@ const fromDispatchFactory =
   <K extends `${Discord.GatewayDispatchEvents}`>(
     event: K,
   ): Stream.Stream<
-    Extract<Discord.GatewayDispatchPayload, { readonly t: K }>["d"],
+    Extract<Discord.DistributedGatewayDispatchPayload, { readonly t: K }>["d"],
     E,
     R
   > =>

--- a/src/types.ts
+++ b/src/types.ts
@@ -148,6 +148,15 @@ export type AllComponents =
   | MessageComponent
   | (Rest.ActionRowComponentResponse["components"] & {})[number]
 
+export type DistributedGatewayDispatchPayload =
+  GatewayDispatchPayload extends infer Payload
+    ? Payload extends _DataPayload<infer Event, infer D>
+      ? Event extends Event
+        ? _DataPayload<Event, D>
+        : never
+      : Payload
+    : never
+
 // =============================================================================
 
 /**


### PR DESCRIPTION
Fixes #7 